### PR TITLE
add ingress to local deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ BookFinder/
 │   │           ├── configmap.yaml
 │   │           ├── frontend-deployment.yaml
 │   │           ├── frontend-service.yaml
+│   │           ├── ingress.yaml
 │   │           └── secret.yaml
 │   └── kustomize/      # Kustomize-ready Kubernetes manifests
 │       ├── kustomization.yaml
@@ -66,6 +67,7 @@ BookFinder/
 │       ├── backend-deployment.yaml
 │       ├── backend-service.yaml
 │       ├── configmap.yaml
+│       ├── ingress.yaml
 │       └── secret.yaml
 ├── iac/                # Terraform files for GCP Autopilot
 │   ├── main.tf
@@ -89,31 +91,50 @@ BookFinder/
 
 ### Option 1: Kustomize Deployment
 
+Follow these steps to deploy BookFinder using Kustomize:
+
 ```bash
-# Clone the repository
+# 1. Clone the repository
 git clone https://github.com/bennymestel/BookFinder.git
 cd BookFinder
 
-# Apply manifests using Kustomize
+# 2. Add a local DNS entry
+# For macOS/Linux:
+echo "127.0.0.1 bookfinder.local" | sudo tee -a /etc/hosts
+# For Windows (run PowerShell as Administrator):
+Add-Content -Path "$env:windir\System32\drivers\etc\hosts" -Value "`n127.0.0.1 bookfinder.local" -Force
+
+# 3. Apply manifests using Kustomize
 kubectl apply -k deployments/kustomize/
 
-# Streamlit will be available at:
-http://localhost
+# 4. Start a tunnel for ingress access (keep this terminal open)
+minikube tunnel
 ```
+
+Once deployed, BookFinder will be available at: http://bookfinder.local
+
+> **Note:** The frontend application may take a few minutes to become fully operational on initial startup. This delay is primarily due to downloading and initializing the ML models (T5 and Sentence-Transformers).
 
 ### Option 2: Helm Deployment
 
+Follow these steps to deploy BookFinder using Helm:
+
 ```bash
-# Clone the repository
+# 1. Clone the repository
 git clone https://github.com/bennymestel/BookFinder.git
 cd BookFinder
 
-# Install using the Helm chart
-helm install bookfinder ./deployments/helm/bookfinder
+# 2. Add a local DNS entry
+# For macOS/Linux:
+echo "127.0.0.1 bookfinder.local" | sudo tee -a /etc/hosts
+# For Windows (run PowerShell as Administrator):
+Add-Content -Path "$env:windir\System32\drivers\etc\hosts" -Value "`n127.0.0.1 bookfinder.local" -Force
 
-# Streamlit will be available at:
-http://localhost
+# 3. Install using the Helm chart
+helm install bookfinder ./deployments/helm/bookfinder
 ```
+
+Once deployed, BookFinder will be available at: http://bookfinder.local
 
 > **Note:** The frontend application may take a few minutes to become fully operational on initial startup. This delay is primarily due to downloading and initializing the ML models (T5 and Sentence-Transformers).
 
@@ -225,3 +246,4 @@ Prebuilt images are hosted on DockerHub:
 - Multiple deployment options: Kustomize and Helm
 - Infrastructure as Code with Terraform
 - Public GCP-compatible deployment path
+- Kubernetes Ingress for unified access

--- a/app/.streamlit/secrets.toml
+++ b/app/.streamlit/secrets.toml
@@ -1,2 +1,7 @@
 [google_books_api_key]
 key = "AIzaSyDlaj5CJnliwC10ZzkDAWRGB-erfzEcHCE"
+
+[server]
+enableCORS = false
+enableXsrfProtection = false
+baseUrlPath = ""

--- a/deployments/helm/bookfinder/templates/ingress.yaml
+++ b/deployments/helm/bookfinder/templates/ingress.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.frontend.name }}-ingress
+  labels:
+    {{- include "bookfinder.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Values.frontend.name }}
+            port:
+              number: {{ .Values.frontend.service.port }}
+{{- end }}

--- a/deployments/helm/bookfinder/templates/secret.yaml
+++ b/deployments/helm/bookfinder/templates/secret.yaml
@@ -9,3 +9,8 @@ stringData:
   secrets.toml: |
     [google_books_api_key]
     key = "{{ .Values.googleBooksApiKey | default "AIzaSyDlaj5CJnliwC10ZzkDAWRGB-erfzEcHCE" }}"
+    
+    [server]
+    enableCORS = {{ .Values.streamlit.server.enableCORS | default false }}
+    enableXsrfProtection = {{ .Values.streamlit.server.enableXsrfProtection | default false }}
+    baseUrlPath = "{{ .Values.streamlit.server.baseUrlPath | default "/" }}"

--- a/deployments/helm/bookfinder/values.yaml
+++ b/deployments/helm/bookfinder/values.yaml
@@ -9,7 +9,7 @@ frontend:
     pullPolicy: IfNotPresent
     tag: "latest"
   service:
-    type: LoadBalancer
+    type: ClusterIP
     port: 80
     targetPort: 8501
   resources:
@@ -39,6 +39,22 @@ backend:
     requests:
       cpu: 200m
       memory: 256Mi
+
+# Ingress configuration
+ingress:
+  enabled: true
+  host: bookfinder.local
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+
+# Streamlit configuration
+streamlit:
+  server:
+    enableCORS: false
+    enableXsrfProtection: false
+    baseUrlPath: "/"
 
 # Chart name overrides (if needed)
 nameOverride: ""

--- a/deployments/kustomize/configmap.yaml
+++ b/deployments/kustomize/configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: bookfinder-config
 data:
-  BACKEND_URL: "http://bookfinder-backend:5000"
+  BACKEND_URL: "http://backend:5000"

--- a/deployments/kustomize/frontend-service.yaml
+++ b/deployments/kustomize/frontend-service.yaml
@@ -9,4 +9,4 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 8501
-  type: LoadBalancer
+  type: ClusterIP

--- a/deployments/kustomize/ingress.yaml
+++ b/deployments/kustomize/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bookfinder-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: bookfinder.local
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: book-finder-frontend
+            port:
+              number: 80

--- a/deployments/kustomize/kustomization.yaml
+++ b/deployments/kustomize/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - backend-service.yaml
 - frontend-deployment.yaml
 - frontend-service.yaml
+- ingress.yaml

--- a/deployments/kustomize/secret.yaml
+++ b/deployments/kustomize/secret.yaml
@@ -7,3 +7,8 @@ stringData:
   secrets.toml: |
     [google_books_api_key]
     key = "AIzaSyDlaj5CJnliwC10ZzkDAWRGB-erfzEcHCE"
+
+    [server]
+    enableCORS = false
+    enableXsrfProtection = false
+    baseUrlPath = "/"


### PR DESCRIPTION
- Introduced ingress.yaml for Kubernetes Ingress configuration.
- Updated values.yaml to include ingress settings and Streamlit server configurations.
- Modified frontend and backend services to use ClusterIP instead of LoadBalancer.
- Adjusted configmap.yaml to correct backend URL.
- Enhanced secret.yaml to include Streamlit server settings.
- Updated kustomization.yaml to include new ingress resource.